### PR TITLE
Add PHP testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ using Webpack Encore. Docker images are provided for local development.
    ```
 
 The application will be available at [http://localhost:8000](http://localhost:8000).
+
+## Testing and Code Quality
+
+Run the following commands inside the container to execute the test suite and quality tools:
+
+```bash
+docker compose run --rm app composer test
+docker compose run --rm app composer phpstan
+docker compose run --rm app composer phpcs
+```

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,11 @@
             "App\\Tests\\": "tests/"
         }
     },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "phpstan/phpstan": "^1.11",
+        "squizlabs/php_codesniffer": "^3.7"
+    },
     "replace": {
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-iconv": "*",
@@ -56,7 +61,10 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "test": "vendor/bin/phpunit",
+        "phpstan": "vendor/bin/phpstan analyse",
+        "phpcs": "vendor/bin/phpcs"
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="Budgertia">
+    <rule ref="PSR12"/>
+    <file>src</file>
+    <file>tests</file>
+</ruleset>
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+    level: 9
+    paths:
+        - src
+        - tests
+

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    public function testTrue(): void
+    {
+        $this->assertTrue(true);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PHPUnit example test
- configure phpstan and phpcs
- expose QA commands via Composer
- document testing commands in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840c71f41a4832c92548fa50ba91bb6