### PR TITLE
Update codex and enable Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,11 @@
         "symfony/twig-bundle": "7.3.*",
         "symfony/webpack-encore-bundle": "^2.2",
         "symfony/yaml": "7.3.*",
-        "twig/twig": "^3.21"
+        "twig/twig": "^3.21",
+        "doctrine/dbal": "^3",
+        "doctrine/orm": "*",
+        "doctrine/doctrine-bundle": "^2.10",
+        "doctrine/doctrine-migrations-bundle": "^3.5"
     },
     "config": {
         "allow-plugins": {

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -4,4 +4,6 @@ return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
 ];

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,3 @@
+doctrine_migrations:
+    migrations_paths:
+        'DoctrineMigrations': '%kernel.project_dir%/migrations'


### PR DESCRIPTION
## Summary
- restore Codex automation rule for lint & tests
- add Doctrine packages and migrations bundle
- register Doctrine bundles in Symfony config

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840dd695088832c9b5582ca5df9b5a6