### PR TITLE
Update AGENT notes for docker setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Always include a trailing newline at EOF
 Do not strip trailing whitespace in Markdown
 
 Development Notes
-PHP and Composer are not installed. Backend logic should be written without requiring test execution.
+PHP 8.2, Composer and Docker are available via `.setup/setup.sh`. Use Docker Compose to run backend tests and quality tools.
 
 Node.js and npm are available. Run npm install if node_modules is missing.
 
@@ -79,5 +79,6 @@ Focus commits on a single responsibility; avoid large mixed changes
 
 Codex Automation
 Codex reads the `codex.custom.yml` file in the project root to know when
-to run automated tasks. The provided configuration runs `npm run lint` and
-`npm run test` only when code files change.
+to run automated tasks. The configuration triggers `npm run lint`, `npm run test`,
+and Docker-based Composer commands for PHPUnit, PHPStan and PHPCS whenever code
+files change.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ to manage the schema.
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) with Compose support
+- PHP 8.2 and Composer (provided by `.setup/setup.sh`)
 - Node.js 18+ and npm
 
 ## Installation

--- a/codex.custom.yml
+++ b/codex.custom.yml
@@ -4,3 +4,6 @@ rules:
     then:
       - run: npm run lint
       - run: npm run test
+      - run: docker compose run --rm app composer test
+      - run: docker compose run --rm app composer phpstan
+      - run: docker compose run --rm app composer phpcs


### PR DESCRIPTION
## Summary
- clarify that PHP, Composer and Docker are available via setup script
- run phpunit, phpstan and phpcs in codex config
- document PHP 8.2 requirement in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840ed2f3a40832cae5ac58fb00341b2