### PR TITLE
Fix PHPStan and PHPCS issues

### DIFF
--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -17,9 +17,11 @@ class Category
     #[ORM\Column(length: 100)]
     private string $name;
 
+    /** @var Collection<int, Transaction> */
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: Transaction::class)]
     private Collection $transactions;
 
+    /** @var Collection<int, BudgetLimit> */
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: BudgetLimit::class)]
     private Collection $budgetLimits;
 
@@ -46,8 +48,19 @@ class Category
         return $this;
     }
 
+    /**
+     * @return Collection<int, Transaction>
+     */
     public function getTransactions(): Collection
     {
         return $this->transactions;
+    }
+
+    /**
+     * @return Collection<int, BudgetLimit>
+     */
+    public function getBudgetLimits(): Collection
+    {
+        return $this->budgetLimits;
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -20,15 +20,19 @@ class User
     #[ORM\Column]
     private string $password;
 
+    /** @var Collection<int, Transaction> */
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: Transaction::class)]
     private Collection $transactions;
 
+    /** @var Collection<int, BudgetLimit> */
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: BudgetLimit::class)]
     private Collection $budgetLimits;
 
+    /** @var Collection<int, SavingsGoal> */
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: SavingsGoal::class)]
     private Collection $savingsGoals;
 
+    /** @var Collection<int, Notification> */
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: Notification::class)]
     private Collection $notifications;
 
@@ -69,8 +73,35 @@ class User
         return $this;
     }
 
+    /**
+     * @return Collection<int, Transaction>
+     */
     public function getTransactions(): Collection
     {
         return $this->transactions;
+    }
+
+    /**
+     * @return Collection<int, BudgetLimit>
+     */
+    public function getBudgetLimits(): Collection
+    {
+        return $this->budgetLimits;
+    }
+
+    /**
+     * @return Collection<int, SavingsGoal>
+     */
+    public function getSavingsGoals(): Collection
+    {
+        return $this->savingsGoals;
+    }
+
+    /**
+     * @return Collection<int, Notification>
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -13,4 +13,3 @@ class ExampleTest extends TestCase
         $this->assertTrue(true);
     }
 }
-


### PR DESCRIPTION
## Summary
- add generics to entity collections
- expose getters for all collections
- fix trailing newline in ExampleTest

## Testing
- `composer phpstan`
- `composer phpcs`
- `npm run build`
- `composer test` *(fails: PHPUnit requires configuration)*
- `npm run lint` *(fails: missing script)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef775100832c8c98ef03eada453f