### PR TITLE
Add JSON API CRUD controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ docker compose run --rm app composer test
 docker compose run --rm app composer phpstan
 docker compose run --rm app composer phpcs
 ```
+
+See `docs/API_USAGE.md` for REST API usage.

--- a/docs/API_USAGE.md
+++ b/docs/API_USAGE.md
@@ -1,0 +1,42 @@
+# API Usage
+
+All endpoints are prefixed with `/api` and require JWT authentication unless stated otherwise.
+
+## Category
+
+- `GET /api/categories` – list categories
+- `POST /api/categories` – create a category
+- `GET /api/categories/{id}` – get a category
+- `PUT /api/categories/{id}` – update a category
+- `DELETE /api/categories/{id}` – remove a category
+
+## Transaction
+
+- `GET /api/transactions` – list your transactions
+- `POST /api/transactions` – create a transaction
+- `GET /api/transactions/{id}` – get a transaction
+- `PUT /api/transactions/{id}` – update a transaction
+- `DELETE /api/transactions/{id}` – delete a transaction
+
+## Budget Limit
+
+- `GET /api/budget-limits` – list your limits
+- `POST /api/budget-limits` – create a limit
+- `GET /api/budget-limits/{id}` – get a limit
+- `PUT /api/budget-limits/{id}` – update a limit
+- `DELETE /api/budget-limits/{id}` – remove a limit
+
+## Savings Goal
+
+- `GET /api/savings-goals` – list your goals
+- `POST /api/savings-goals` – create a goal
+- `GET /api/savings-goals/{id}` – get a goal
+- `PUT /api/savings-goals/{id}` – update a goal
+- `DELETE /api/savings-goals/{id}` – delete a goal
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -H "Authorization: Bearer <token>" \
+     -d '{"name":"Groceries"}' \
+     http://localhost:8000/api/categories
+```

--- a/src/Controller/BudgetLimitController.php
+++ b/src/Controller/BudgetLimitController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\BudgetLimit;
+use App\Entity\Category;
+use App\Entity\User;
+use App\Service\JsonApi;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/budget-limits')]
+class BudgetLimitController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private JsonApi $jsonApi
+    ) {
+    }
+
+    #[Route('', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        $limits = $this->entityManager->getRepository(BudgetLimit::class)
+            ->findBy(['user' => $user]);
+
+        $items = [];
+        foreach ($limits as $limit) {
+            $items[] = [
+                'type' => 'budget-limit',
+                'id' => (string) $limit->getId(),
+                'attributes' => [
+                    'amount' => $limit->getAmount(),
+                    'category' => $limit->getCategory()->getId(),
+                ],
+            ];
+        }
+
+        return new JsonResponse($this->jsonApi->collection($items));
+    }
+
+    #[Route('', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+
+        $category = $this->entityManager->find(Category::class, $payload['category'] ?? 0);
+        if (!$category) {
+            return new JsonResponse(['errors' => [['detail' => 'Category not found']]], 404);
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $limit = new BudgetLimit();
+        $limit->setAmount((int) ($payload['amount'] ?? 0));
+        $limit->setCategory($category);
+        $limit->setUser($user);
+
+        $this->entityManager->persist($limit);
+        $this->entityManager->flush();
+
+        $id = $limit->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('budget-limit', $id, [
+                'amount' => $limit->getAmount(),
+                'category' => $limit->getCategory()->getId(),
+            ]),
+            201
+        );
+    }
+
+    #[Route('/{id}', methods: ['GET'])]
+    public function show(BudgetLimit $budgetLimit): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($budgetLimit->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $id = $budgetLimit->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('budget-limit', $id, [
+                'amount' => $budgetLimit->getAmount(),
+                'category' => $budgetLimit->getCategory()->getId(),
+            ])
+        );
+    }
+
+    #[Route('/{id}', methods: ['PUT'])]
+    public function update(Request $request, BudgetLimit $budgetLimit): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($budgetLimit->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+        if (isset($payload['amount'])) {
+            $budgetLimit->setAmount((int) $payload['amount']);
+        }
+        if (isset($payload['category'])) {
+            $category = $this->entityManager->find(Category::class, $payload['category']);
+            if (!$category) {
+                return new JsonResponse(['errors' => [['detail' => 'Category not found']]], 404);
+            }
+            $budgetLimit->setCategory($category);
+        }
+
+        $this->entityManager->flush();
+
+        $id = $budgetLimit->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('budget-limit', $id, [
+                'amount' => $budgetLimit->getAmount(),
+                'category' => $budgetLimit->getCategory()->getId(),
+            ])
+        );
+    }
+
+    #[Route('/{id}', methods: ['DELETE'])]
+    public function delete(BudgetLimit $budgetLimit): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($budgetLimit->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $this->entityManager->remove($budgetLimit);
+        $this->entityManager->flush();
+
+        return new JsonResponse(null, 204);
+    }
+}

--- a/src/Controller/CategoryController.php
+++ b/src/Controller/CategoryController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Category;
+use App\Service\JsonApi;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/categories')]
+class CategoryController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private JsonApi $jsonApi
+    ) {
+    }
+
+    #[Route('', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $categories = $this->entityManager->getRepository(Category::class)->findAll();
+
+        $items = [];
+        foreach ($categories as $category) {
+            $items[] = [
+                'type' => 'category',
+                'id' => (string) $category->getId(),
+                'attributes' => [
+                    'name' => $category->getName(),
+                ],
+            ];
+        }
+
+        return new JsonResponse($this->jsonApi->collection($items));
+    }
+
+    #[Route('', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+        $name = isset($payload['name']) ? (string) $payload['name'] : '';
+
+        $category = new Category();
+        $category->setName($name);
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+
+        $id = $category->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('category', $id, ['name' => $category->getName()]),
+            201
+        );
+    }
+
+    #[Route('/{id}', methods: ['GET'])]
+    public function show(Category $category): JsonResponse
+    {
+        $id = $category->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('category', $id, ['name' => $category->getName()])
+        );
+    }
+
+    #[Route('/{id}', methods: ['PUT'])]
+    public function update(Request $request, Category $category): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+        if (isset($payload['name'])) {
+            $category->setName((string) $payload['name']);
+        }
+        $this->entityManager->flush();
+
+        $id = $category->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('category', $id, ['name' => $category->getName()])
+        );
+    }
+
+    #[Route('/{id}', methods: ['DELETE'])]
+    public function delete(Category $category): JsonResponse
+    {
+        $this->entityManager->remove($category);
+        $this->entityManager->flush();
+
+        return new JsonResponse(null, 204);
+    }
+}

--- a/src/Controller/SavingsGoalController.php
+++ b/src/Controller/SavingsGoalController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\SavingsGoal;
+use App\Entity\User;
+use App\Service\JsonApi;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/savings-goals')]
+class SavingsGoalController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private JsonApi $jsonApi
+    ) {
+    }
+
+    #[Route('', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        $goals = $this->entityManager->getRepository(SavingsGoal::class)
+            ->findBy(['user' => $user]);
+
+        $items = [];
+        foreach ($goals as $goal) {
+            $items[] = [
+                'type' => 'savings-goal',
+                'id' => (string) $goal->getId(),
+                'attributes' => [
+                    'targetAmount' => $goal->getTargetAmount(),
+                    'currentAmount' => $goal->getCurrentAmount(),
+                ],
+            ];
+        }
+
+        return new JsonResponse($this->jsonApi->collection($items));
+    }
+
+    #[Route('', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $goal = new SavingsGoal();
+        $goal->setTargetAmount((int) ($payload['targetAmount'] ?? 0));
+        $goal->setCurrentAmount((int) ($payload['currentAmount'] ?? 0));
+        $goal->setUser($user);
+
+        $this->entityManager->persist($goal);
+        $this->entityManager->flush();
+
+        $id = $goal->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('savings-goal', $id, [
+                'targetAmount' => $goal->getTargetAmount(),
+                'currentAmount' => $goal->getCurrentAmount(),
+            ]),
+            201
+        );
+    }
+
+    #[Route('/{id}', methods: ['GET'])]
+    public function show(SavingsGoal $savingsGoal): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($savingsGoal->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $id = $savingsGoal->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('savings-goal', $id, [
+                'targetAmount' => $savingsGoal->getTargetAmount(),
+                'currentAmount' => $savingsGoal->getCurrentAmount(),
+            ])
+        );
+    }
+
+    #[Route('/{id}', methods: ['PUT'])]
+    public function update(Request $request, SavingsGoal $savingsGoal): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($savingsGoal->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+        if (isset($payload['targetAmount'])) {
+            $savingsGoal->setTargetAmount((int) $payload['targetAmount']);
+        }
+        if (isset($payload['currentAmount'])) {
+            $savingsGoal->setCurrentAmount((int) $payload['currentAmount']);
+        }
+
+        $this->entityManager->flush();
+
+        $id = $savingsGoal->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('savings-goal', $id, [
+                'targetAmount' => $savingsGoal->getTargetAmount(),
+                'currentAmount' => $savingsGoal->getCurrentAmount(),
+            ])
+        );
+    }
+
+    #[Route('/{id}', methods: ['DELETE'])]
+    public function delete(SavingsGoal $savingsGoal): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($savingsGoal->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $this->entityManager->remove($savingsGoal);
+        $this->entityManager->flush();
+
+        return new JsonResponse(null, 204);
+    }
+}

--- a/src/Controller/TransactionController.php
+++ b/src/Controller/TransactionController.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Transaction;
+use App\Entity\Category;
+use App\Entity\User;
+use App\Service\JsonApi;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/transactions')]
+class TransactionController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private JsonApi $jsonApi
+    ) {
+    }
+
+    #[Route('', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        $transactions = $this->entityManager->getRepository(Transaction::class)
+            ->findBy(['user' => $user]);
+
+        $items = [];
+        foreach ($transactions as $transaction) {
+            $items[] = [
+                'type' => 'transaction',
+                'id' => (string) $transaction->getId(),
+                'attributes' => [
+                    'amount' => $transaction->getAmount(),
+                    'description' => $transaction->getDescription(),
+                    'date' => $transaction->getDate()->format(DATE_ATOM),
+                    'category' => $transaction->getCategory()?->getId(),
+                ],
+            ];
+        }
+
+        return new JsonResponse($this->jsonApi->collection($items));
+    }
+
+    #[Route('', methods: ['POST'])]
+    public function create(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+        $categoryId = $payload['category'] ?? null;
+        $category = null;
+        if ($categoryId) {
+            $category = $this->entityManager->find(Category::class, $categoryId);
+            if (!$category) {
+                return new JsonResponse(['errors' => [['detail' => 'Category not found']]], 404);
+            }
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $transaction = new Transaction();
+        $transaction->setAmount((int) ($payload['amount'] ?? 0));
+        $transaction->setDescription((string) ($payload['description'] ?? ''));
+        $transaction->setDate(new \DateTimeImmutable($payload['date'] ?? 'now'));
+        $transaction->setUser($user);
+        $transaction->setCategory($category);
+
+        $this->entityManager->persist($transaction);
+        $this->entityManager->flush();
+
+        $id = $transaction->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('transaction', $id, [
+                'amount' => $transaction->getAmount(),
+                'description' => $transaction->getDescription(),
+                'date' => $transaction->getDate()->format(DATE_ATOM),
+                'category' => $transaction->getCategory()?->getId(),
+            ]),
+            201
+        );
+    }
+
+    #[Route('/{id}', methods: ['GET'])]
+    public function show(Transaction $transaction): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($transaction->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $id = $transaction->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('transaction', $id, [
+                'amount' => $transaction->getAmount(),
+                'description' => $transaction->getDescription(),
+                'date' => $transaction->getDate()->format(DATE_ATOM),
+                'category' => $transaction->getCategory()?->getId(),
+            ])
+        );
+    }
+
+    #[Route('/{id}', methods: ['PUT'])]
+    public function update(Request $request, Transaction $transaction): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($transaction->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+
+        if (isset($payload['amount'])) {
+            $transaction->setAmount((int) $payload['amount']);
+        }
+        if (isset($payload['description'])) {
+            $transaction->setDescription((string) $payload['description']);
+        }
+        if (isset($payload['date'])) {
+            $transaction->setDate(new \DateTimeImmutable($payload['date']));
+        }
+        if (array_key_exists('category', $payload)) {
+            $categoryId = $payload['category'];
+            $category = null;
+            if ($categoryId) {
+                $category = $this->entityManager->find(Category::class, $categoryId);
+                if (!$category) {
+                    return new JsonResponse(['errors' => [['detail' => 'Category not found']]], 404);
+                }
+            }
+            $transaction->setCategory($category);
+        }
+
+        $this->entityManager->flush();
+
+        $id = $transaction->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('transaction', $id, [
+                'amount' => $transaction->getAmount(),
+                'description' => $transaction->getDescription(),
+                'date' => $transaction->getDate()->format(DATE_ATOM),
+                'category' => $transaction->getCategory()?->getId(),
+            ])
+        );
+    }
+
+    #[Route('/{id}', methods: ['DELETE'])]
+    public function delete(Transaction $transaction): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($transaction->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $this->entityManager->remove($transaction);
+        $this->entityManager->flush();
+
+        return new JsonResponse(null, 204);
+    }
+}

--- a/src/Service/JsonApi.php
+++ b/src/Service/JsonApi.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Service;
+
+class JsonApi
+{
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array{data: array{type: string, id: string, attributes: array<string, mixed>}}
+     */
+    public function item(string $type, int|string $id, array $attributes): array
+    {
+        return [
+            'data' => [
+                'type' => $type,
+                'id' => (string) $id,
+                'attributes' => $attributes,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array{type: string, id: string, attributes: array<string, mixed>}> $items
+     *
+     * @return array{data: array<int, array{type: string, id: string, attributes: array<string, mixed>}>}
+     */
+    public function collection(array $items): array
+    {
+        return ['data' => $items];
+    }
+}


### PR DESCRIPTION
## Summary
- add JsonApi service
- add CRUD API controllers for Category, Transaction, BudgetLimit and SavingsGoal
- document REST endpoints

## Testing
- `composer phpstan`
- `vendor/bin/phpcs -n -v src`
- `composer test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684150b9f4c0832c9d44d1ab285ce727