### PR TITLE
Fix SQLite migration failure

### DIFF
--- a/docs/DB_NOTES.md
+++ b/docs/DB_NOTES.md
@@ -1,0 +1,8 @@
+# Database Notes
+
+The `Transaction` entity now maps to the `transactions` table instead of the
+reserved keyword `transaction`. Run migrations to create or update the schema:
+
+```bash
+docker compose run --rm app php bin/console doctrine:migrations:migrate
+```

--- a/migrations/Version202501010000.php
+++ b/migrations/Version202501010000.php
@@ -11,17 +11,17 @@ final class Version202501010000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Initial migration creating transaction table';
+        return 'Initial migration creating transactions table';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE transaction (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, amount INTEGER NOT NULL, description VARCHAR(255) NOT NULL)');
+        $this->addSql('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, amount INTEGER NOT NULL, description VARCHAR(255) NOT NULL)');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP TABLE transaction');
+        $this->addSql('DROP TABLE transactions');
     }
 }
 

--- a/migrations/Version202501010001.php
+++ b/migrations/Version202501010001.php
@@ -16,13 +16,13 @@ final class Version202501010001 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('DROP TABLE IF EXISTS transaction');
+        $this->addSql('DROP TABLE IF EXISTS transactions');
         $this->addSql('CREATE TABLE user (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, email VARCHAR(180) NOT NULL, password VARCHAR(255) NOT NULL)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649E7927C74 ON user (email)');
         $this->addSql('CREATE TABLE category (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(100) NOT NULL)');
-        $this->addSql('CREATE TABLE transaction (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, user_id INTEGER NOT NULL, category_id INTEGER DEFAULT NULL, amount INTEGER NOT NULL, description VARCHAR(255) NOT NULL, date DATETIME NOT NULL, CONSTRAINT FK_723705D1A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT FK_723705D112469DE2 FOREIGN KEY (category_id) REFERENCES category (id) NOT DEFERRABLE INITIALLY IMMEDIATE)');
-        $this->addSql('CREATE INDEX IDX_723705D1A76ED395 ON transaction (user_id)');
-        $this->addSql('CREATE INDEX IDX_723705D112469DE2 ON transaction (category_id)');
+        $this->addSql('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, user_id INTEGER NOT NULL, category_id INTEGER DEFAULT NULL, amount INTEGER NOT NULL, description VARCHAR(255) NOT NULL, date DATETIME NOT NULL, CONSTRAINT FK_723705D1A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT FK_723705D112469DE2 FOREIGN KEY (category_id) REFERENCES category (id) NOT DEFERRABLE INITIALLY IMMEDIATE)');
+        $this->addSql('CREATE INDEX IDX_723705D1A76ED395 ON transactions (user_id)');
+        $this->addSql('CREATE INDEX IDX_723705D112469DE2 ON transactions (category_id)');
         $this->addSql('CREATE TABLE budget_limit (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, category_id INTEGER NOT NULL, user_id INTEGER NOT NULL, amount INTEGER NOT NULL, CONSTRAINT FK_7E13306B12469DE2 FOREIGN KEY (category_id) REFERENCES category (id) NOT DEFERRABLE INITIALLY IMMEDIATE, CONSTRAINT FK_7E13306BA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) NOT DEFERRABLE INITIALLY IMMEDIATE)');
         $this->addSql('CREATE INDEX IDX_7E13306B12469DE2 ON budget_limit (category_id)');
         $this->addSql('CREATE INDEX IDX_7E13306BA76ED395 ON budget_limit (user_id)');
@@ -34,7 +34,7 @@ final class Version202501010001 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP TABLE transaction');
+        $this->addSql('DROP TABLE transactions');
         $this->addSql('DROP TABLE budget_limit');
         $this->addSql('DROP TABLE savings_goal');
         $this->addSql('DROP TABLE notification');

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -7,6 +7,7 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
+#[ORM\Table(name: 'transactions')]
 class Transaction
 {
     #[ORM\Id]


### PR DESCRIPTION
## Summary
- escape reserved `transaction` table name
- update entity and migrations to use `transactions` table
- document updated table name

## Testing
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`
- `php bin/console doctrine:migrations:migrate --no-interaction` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68415a487040832ca0d60f2360f4494b