### PR TITLE
Add user docs interface

### DIFF
--- a/assets/vue/App.vue
+++ b/assets/vue/App.vue
@@ -1,5 +1,8 @@
 <template>
-  <h1>Hello Vue!</h1>
+  <div>
+    <h1>Hello Vue!</h1>
+    <p><a href="/docs">View Documentation</a></p>
+  </div>
 </template>
 
 <script>
@@ -7,3 +10,4 @@ export default {
   name: 'App'
 }
 </script>
+

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
         "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "doctrine/dbal": "^3",
+        "doctrine/doctrine-bundle": "^2.10",
+        "doctrine/doctrine-migrations-bundle": "^3.4",
+        "doctrine/orm": "*",
+        "lexik/jwt-authentication-bundle": "^3.1.1",
         "symfony/console": "7.3.*",
         "symfony/dotenv": "7.3.*",
         "symfony/flex": "^2",
@@ -17,12 +22,8 @@
         "symfony/twig-bundle": "7.3.*",
         "symfony/webpack-encore-bundle": "^2.2",
         "symfony/yaml": "7.3.*",
-        "twig/twig": "^3.21",
-        "doctrine/dbal": "^3",
-        "doctrine/orm": "*",
-        "doctrine/doctrine-bundle": "^2.10",
-        "doctrine/doctrine-migrations-bundle": "^3.4",
-        "lexik/jwt-authentication-bundle": "^3.1.1"
+        "twig/markdown-extra": "^3.21",
+        "twig/twig": "^3.21"
     },
 
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "386b6d874bcc7480a653d9a9af9ed125",
+    "content-hash": "d8ca64d6fd794521c7832e570f581164",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -5345,6 +5345,78 @@
                 }
             ],
             "time": "2025-04-04T10:10:33+00:00"
+        },
+        {
+            "name": "twig/markdown-extra",
+            "version": "v3.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/markdown-extra.git",
+                "reference": "f4616e1dd375209dacf6026f846e6b537d036ce4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/markdown-extra/zipball/f4616e1dd375209dacf6026f846e6b537d036ce4",
+                "reference": "f4616e1dd375209dacf6026f846e6b537d036ce4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "twig/twig": "^3.13|^4.0"
+            },
+            "require-dev": {
+                "erusev/parsedown": "dev-master as 1.x-dev",
+                "league/commonmark": "^1.0|^2.0",
+                "league/html-to-markdown": "^4.8|^5.0",
+                "michelf/php-markdown": "^1.8|^2.0",
+                "symfony/phpunit-bridge": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Twig\\Extra\\Markdown\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Markdown",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "html",
+                "markdown",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/markdown-extra/tree/v3.21.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-31T20:45:36+00:00"
         },
         {
             "name": "twig/twig",

--- a/docs/HELP_INTERFACE.md
+++ b/docs/HELP_INTERFACE.md
@@ -1,0 +1,4 @@
+# Documentation Access
+
+Navigate to `/docs` in your browser to view built-in documentation about Budgertia's API. The page shows the contents of `docs/API_USAGE.md`.
+

--- a/src/Controller/DocsController.php
+++ b/src/Controller/DocsController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DocsController extends AbstractController
+{
+    #[Route('/docs', name: 'app_docs')]
+    public function index(): Response
+    {
+        $path = dirname(__DIR__, 2) . '/docs/API_USAGE.md';
+        $content = is_readable($path) ? file_get_contents($path) : 'Documentation not found.';
+
+        return $this->render('docs.html.twig', [
+            'doc_content' => $content,
+        ]);
+    }
+}

--- a/templates/docs.html.twig
+++ b/templates/docs.html.twig
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Budgertia Documentation</title>
+    {{ encore_entry_link_tags('app') }}
+</head>
+<body>
+<h1>How to Use Budgertia</h1>
+<pre>{{ doc_content }}</pre>
+{{ encore_entry_script_tags('app') }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/docs` route with DocsController to display API guide
- include page template for showing docs
- link to the docs page in the Vue app
- document how to access the new interface
- require markdown-extra for Twig

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849b9fc5c40832c98896dcd117d1ad1