### PR TITLE
Fix PHP-FPM warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN apt-get update && apt-get install -y \
         git unzip libicu-dev \
     && docker-php-ext-install intl opcache
 
+# Remove user and group directives as PHP-FPM runs under the
+# non-root "app" user defined below. Leaving these directives
+# triggers noisy notices during container start-up.
+RUN sed -i '/^user =/d;/^group =/d' /usr/local/etc/php-fpm.d/www.conf
+
 # ── Non-root user matching host ────────────────────────────
 RUN groupadd -g ${GID} app \
  && useradd  -m -u ${UID} -g app app


### PR DESCRIPTION
## Summary
- remove user/group directives from PHP-FPM pool config to silence startup notices

## Testing
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run lint` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849bc29cc80832ca68bde18760ac8ee