### PR TITLE
Implement user registration API

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+DATABASE_URL="sqlite:///:memory:"
+

--- a/docs/API_USAGE.md
+++ b/docs/API_USAGE.md
@@ -2,6 +2,18 @@
 
 All endpoints are prefixed with `/api` and require JWT authentication unless stated otherwise.
 
+## Auth
+
+- `POST /api/register` – create a user
+- `POST /api/login` – obtain a token
+- `POST /api/token/refresh` – refresh a token
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"email":"john@example.com","password":"secret"}' \
+     http://localhost:8000/api/register
+```
+
 ## Category
 
 - `GET /api/categories` – list categories

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -14,6 +14,7 @@
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
+        <server name="KERNEL_CLASS" value="App\\Kernel" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Service\UserService;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -15,6 +16,29 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class AuthController extends AbstractController
 {
+    #[Route('/api/register', name: 'api_register', methods: ['POST'])]
+    public function register(
+        Request $request,
+        UserService $userService,
+        JWTManager $jwtManager
+    ): JsonResponse {
+        $data = json_decode($request->getContent(), true);
+        $payload = is_array($data) ? $data : [];
+        $email = isset($payload['email']) ? (string) $payload['email'] : '';
+        $password = isset($payload['password']) ? (string) $payload['password'] : '';
+
+        if ($email === '' || $password === '') {
+            return new JsonResponse(['message' => 'Invalid data'], 400);
+        }
+
+        try {
+            $user = $userService->register($email, $password);
+        } catch (\RuntimeException $e) {
+            return new JsonResponse(['message' => $e->getMessage()], 400);
+        }
+
+        return new JsonResponse(['token' => $jwtManager->create($user)], 201);
+    }
     #[Route('/api/login', name: 'api_login', methods: ['POST'])]
     public function login(
         Request $request,

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+final class UserService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserPasswordHasherInterface $passwordHasher
+    ) {
+    }
+
+    public function register(string $email, string $password): User
+    {
+        if ($this->entityManager->getRepository(User::class)->findOneBy(['email' => $email])) {
+            throw new \RuntimeException('Email already registered');
+        }
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setPassword($this->passwordHasher->hashPassword($user, $password));
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/tests/Controller/AuthControllerTest.php
+++ b/tests/Controller/AuthControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+use Doctrine\ORM\Tools\SchemaTool;
+
+class AuthControllerTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        self::bootKernel();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+        $schemaTool = new SchemaTool($entityManager);
+        $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testRegisterEndpoint(): void
+    {
+        /** @var HttpKernelBrowser $client */
+        $client = static::createClient();
+        /* @phpstan-ignore-next-line */
+        $client->request(
+            'POST',
+            '/api/register',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['email' => 'john@example.com', 'password' => 'secret'])
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+        /* @phpstan-ignore-next-line */
+        $data = json_decode($client->getResponse()->getContent(), true);
+        \assert(is_array($data));
+        $this->assertArrayHasKey('token', $data);
+    }
+}

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\UserService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+
+class UserServiceTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    private EntityManagerInterface $entityManager;
+    private UserPasswordHasherInterface $passwordHasher;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        self::bootKernel();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+        $passwordHasher = $container->get(UserPasswordHasherInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+        \assert($passwordHasher instanceof UserPasswordHasherInterface);
+        $this->entityManager = $entityManager;
+        $this->passwordHasher = $passwordHasher;
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testRegisterCreatesUser(): void
+    {
+        $service = new UserService($this->entityManager, $this->passwordHasher);
+        $user = $service->register('a@example.com', 'secret');
+
+        $this->assertSame('a@example.com', $user->getEmail());
+        $this->assertTrue($this->passwordHasher->isPasswordValid($user, 'secret'));
+    }
+
+    public function testRegisterDuplicateThrows(): void
+    {
+        $service = new UserService($this->entityManager, $this->passwordHasher);
+        $service->register('a@example.com', 'secret');
+
+        $this->expectException(\RuntimeException::class);
+        $service->register('a@example.com', 'secret');
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserService` for creating new user accounts
- expose registration endpoint in `AuthController`
- document auth endpoints in `API_USAGE.md`
- provide env for tests and update phpunit config
- add unit and integration tests for registration

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849bf4ec6b4832c8b5e4dc5ae4c678a