### PR TITLE
Fix register route security

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ You are Codex, an AI full-stack developer agent for this Symfony 7.3 project usi
 - Node.js and npm are available. Run `npm install` if `node_modules` is missing.
 - Validate all front-end changes using `npm run build`.
 - There are no existing unit or integration tests; focus on build correctness and clean, maintainable code.
+- Ensure the `/api/register` endpoint remains publicly accessible in `security.yaml` so new users can sign up without a token.
 
 ## Best Practices
 ### Symfony & PHP (8.2+)

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -21,6 +21,7 @@ security:
     access_control:
         - { path: ^/api/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/token/refresh, roles: PUBLIC_ACCESS }
+        - { path: ^/api/register, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
 
 when@test:

--- a/docs/API_USAGE.md
+++ b/docs/API_USAGE.md
@@ -1,6 +1,6 @@
 # API Usage
 
-All endpoints are prefixed with `/api` and require JWT authentication unless stated otherwise.
+All endpoints are prefixed with `/api` and require JWT authentication unless stated otherwise. The `POST /api/register` route is publicly accessible so new users can create an account without a token.
 
 ## Auth
 


### PR DESCRIPTION
## Summary
- allow `/api/register` without auth
- document open registration
- update agent notes for register route

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`
- `composer test`
- `composer phpstan`
- `composer phpcs`


------
https://chatgpt.com/codex/tasks/task_e_6849cf97d510832c93ffbeb38325a98f