### PR TITLE
Add Qodana static analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ You are Codex, an AI full-stack developer agent for this Symfony 7.3 project usi
 - Use Docker Compose to run the application. Execute quality tools through Composer:
   - `composer test`
   - `composer phpstan`
-  - `composer phpcs`
+- `composer phpcs`
+- Run Php Inspections (EA Extended) using [Qodana](https://github.com/JetBrains/qodana-cli) or the PhpStorm plugin. A basic command is:
+  `docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0`
 - Node.js and npm are available. Run `npm install` if `node_modules` is missing.
 - Validate all front-end changes using `npm run build`.
 - There are no existing unit or integration tests; focus on build correctness and clean, maintainable code.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Run the following commands inside the container to execute the test suite and qu
 docker compose run --rm app composer test
 docker compose run --rm app composer phpstan
 docker compose run --rm app composer phpcs
+docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0
 npm run lint
 npm run test
 ```

--- a/codex.custom.yml
+++ b/codex.custom.yml
@@ -7,3 +7,4 @@ rules:
       - run: composer test
       - run: composer phpstan
       - run: composer phpcs
+      - run: docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0


### PR DESCRIPTION
## Summary
- document running Php Inspections EA via Qodana
- invoke Qodana in Codex automation
- show how to run Qodana in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run test` *(fails: jest not found)*
- `composer test` *(fails: vendor/bin/phpunit not found)*
- `composer phpstan` *(fails: vendor/bin/phpstan not found)*
- `composer phpcs` *(fails: vendor/bin/phpcs not found)*
- `npm run build` *(fails: encore not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4890db8832c862c5985909b758e