### PR TITLE
Add docs for JWT key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@ to manage the schema.
 
 2. Install PHP dependencies inside the container:
 
-   ```bash
-   docker compose run --rm app composer install
-   ```
+    ```bash
+docker compose run --rm app composer install
+    ```
 
-3. Start the stack:
+3. Generate JWT keys:
 
-   ```bash
-   docker compose up --build
-   ```
+    ```bash
+docker compose run --rm app php bin/console lexik:jwt:generate-keypair --no-interaction --skip-if-exists
+    ```
+
+4. Start the stack:
+
+    ```bash
+    docker compose up --build
+    ```
 
 The application will be available at [http://localhost:8000](http://localhost:8000).
 
@@ -56,3 +62,4 @@ npm run test
 ```
 
 See `docs/API_USAGE.md` for REST API usage.
+See `docs/JWT_KEYS.md` for generating JWT keys.

--- a/docs/JWT_KEYS.md
+++ b/docs/JWT_KEYS.md
@@ -1,0 +1,12 @@
+# JWT Key Setup
+
+Budgertia uses LexikJWTAuthenticationBundle for stateless API authentication. Generate a key pair before running the app.
+
+```bash
+# inside the project root
+mkdir -p config/jwt
+php bin/console lexik:jwt:generate-keypair --skip-if-exists --no-interaction
+```
+
+The command reads `JWT_PASSPHRASE` from your environment. Keys are stored in `config/jwt/private.pem` and `config/jwt/public.pem`. Regenerate them anytime by rerunning the command with `--overwrite`.
+


### PR DESCRIPTION
## Summary
- document how to generate Lexik JWT key pair
- reference the new guide in the README

## Testing
- `npm run lint`
- `npm run test`
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`
- ❌ `docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0` (failed: `docker: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_684a00a0c654832caa0c783c665ac724