### PR TITLE
Add API tester page

### DIFF
--- a/assets/__tests__/request.test.js
+++ b/assets/__tests__/request.test.js
@@ -1,0 +1,15 @@
+const { buildOptions } = require('../utils/request');
+
+test('buildOptions sets headers and body', () => {
+    const opts = buildOptions('POST', 'abc', '{"a":1}');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers.Authorization).toBe('Bearer abc');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    expect(opts.body).toBe('{"a":1}');
+});
+
+test('buildOptions omits body for GET', () => {
+    const opts = buildOptions('GET', '', '');
+    expect(opts.method).toBe('GET');
+    expect(opts.body).toBeUndefined();
+});

--- a/assets/tester.js
+++ b/assets/tester.js
@@ -1,0 +1,5 @@
+import './styles/app.css';
+import { createApp } from 'vue';
+import EndpointTester from './vue/EndpointTester.vue';
+
+createApp(EndpointTester).mount('#tester');

--- a/assets/utils/request.js
+++ b/assets/utils/request.js
@@ -1,0 +1,13 @@
+function buildOptions(method, token, body) {
+    const options = { method, headers: {} };
+    if (token) {
+        options.headers.Authorization = `Bearer ${token}`;
+    }
+    if (body && method !== 'GET') {
+        options.headers['Content-Type'] = 'application/json';
+        options.body = body;
+    }
+    return options;
+}
+
+module.exports = { buildOptions };

--- a/assets/vue/EndpointTester.vue
+++ b/assets/vue/EndpointTester.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <h1>API Tester</h1>
+    <div>
+      <label>Token
+        <input
+          v-model="token"
+          placeholder="JWT token"
+        >
+      </label>
+    </div>
+    <div>
+      <label>Method
+        <select v-model="method">
+          <option
+            v-for="m in methods"
+            :key="m"
+            :value="m"
+          >{{ m }}</option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <label>Endpoint
+        <input
+          v-model="endpoint"
+          placeholder="/api/categories"
+        >
+      </label>
+    </div>
+    <div>
+      <label>Body</label>
+      <textarea v-model="body" />
+    </div>
+    <button @click="send">
+      Send
+    </button>
+    <div v-if="status !== null">
+      <h2>Status: {{ status }}</h2>
+      <pre>{{ response }}</pre>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { buildOptions } from '../utils/request';
+
+const token = ref('');
+const method = ref('GET');
+const endpoint = ref('');
+const body = ref('');
+const status = ref(null);
+const response = ref('');
+
+const methods = ['GET', 'POST', 'PUT', 'DELETE'];
+
+function send() {
+  status.value = null;
+  response.value = '';
+  const options = buildOptions(method.value, token.value, body.value);
+  fetch(endpoint.value, options)
+    .then(async res => {
+      status.value = res.status;
+      response.value = await res.text();
+    })
+    .catch(err => {
+      status.value = 0;
+      response.value = String(err);
+    });
+}
+</script>
+
+<style scoped>
+textarea {
+  width: 100%;
+  height: 150px;
+}
+pre {
+  background: #f8f9fa;
+  padding: 1em;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>
+

--- a/docs/API_TESTER.md
+++ b/docs/API_TESTER.md
@@ -1,0 +1,10 @@
+# API Tester
+
+Visit `/tester` in your browser to interact with Budgertia's REST API.
+
+1. Enter a JWT token from `/api/login` or `/api/register`.
+2. Choose the HTTP method.
+3. Provide the endpoint path, e.g. `/api/categories`.
+4. Enter a JSON body for POST or PUT requests.
+5. Click **Send** to view the status and response body.
+

--- a/src/Controller/TesterController.php
+++ b/src/Controller/TesterController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class TesterController extends AbstractController
+{
+    #[Route('/tester', name: 'app_tester')]
+    public function index(): Response
+    {
+        return $this->render('tester.html.twig');
+    }
+}

--- a/templates/tester.html.twig
+++ b/templates/tester.html.twig
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>API Tester</title>
+    {{ encore_entry_link_tags('tester') }}
+</head>
+<body>
+<div id="tester"></div>
+{{ encore_entry_script_tags('tester') }}
+</body>
+</html>

--- a/tests/Controller/TesterControllerTest.php
+++ b/tests/Controller/TesterControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+class TesterControllerTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        if (!class_exists(\Symfony\Component\BrowserKit\AbstractBrowser::class)) {
+            self::markTestSkipped('BrowserKit missing');
+        }
+    }
+
+    public function testTesterPageLoads(): void
+    {
+        /** @var HttpKernelBrowser $client */
+        $client = static::createClient();
+        /* @phpstan-ignore-next-line */
+        $client->request('GET', '/tester');
+
+        $this->assertResponseIsSuccessful();
+        /* @phpstan-ignore-next-line */
+        $this->assertStringContainsString('id="tester"', $client->getResponse()->getContent());
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ Encore
      * and one CSS file (e.g. app.css) if your JavaScript imports CSS.
      */
     .addEntry('app', './assets/app.js')
+    .addEntry('tester', './assets/tester.js')
 
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     .splitEntryChunks()


### PR DESCRIPTION
## Summary
- create tester GUI via new Vue component and controller
- add request utility and Jest tests
- document tester usage
- compile new Webpack entry

## Testing
- `npm run lint`
- `npm run test`
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a1b8c8a8c832c80336f335373cbba