### PR TITLE
Add notification persistence with new fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ npm run test
 
 See `docs/API_USAGE.md` for REST API usage.
 See `docs/JWT_KEYS.md` for generating JWT keys.
+See `docs/NOTIFICATIONS.md` for how notifications work.

--- a/docs/DB_NOTES.md
+++ b/docs/DB_NOTES.md
@@ -7,3 +7,4 @@ docker compose run --rm app php bin/console doctrine:migrations:migrate
 ```
 
 User roles are stored as a JSON array in the `roles` column added by `Version202501010002`. Run the migration after pulling updates.
+Notifications now include `level` and `is_read` columns added by `Version202501010003`.

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,18 @@
+# Notifications
+
+Budgertia stores alerts for each user in the `notification` table.
+Use them to surface events like budget overruns.
+
+## Fields
+
+- `message` – text to display
+- `level` – info, warning or danger
+- `createdAt` – timestamp
+- `isRead` – whether the user has seen the alert
+
+## Example
+
+```bash
+# list notifications
+curl -H "Authorization: Bearer <token>" http://localhost:8000/api/notifications
+```

--- a/migrations/Version202501010003.php
+++ b/migrations/Version202501010003.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version202501010003 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add level and is_read columns to notification table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE notification ADD COLUMN level VARCHAR(50) NOT NULL DEFAULT 'info'");
+        $this->addSql('ALTER TABLE notification ADD COLUMN is_read BOOLEAN NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE TEMPORARY TABLE __temp__notification AS SELECT id, user_id, message, created_at FROM notification');
+        $this->addSql('DROP TABLE notification');
+        $this->addSql('CREATE TABLE notification (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, user_id INTEGER NOT NULL, message VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, CONSTRAINT FK_BF5476CAA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) NOT DEFERRABLE INITIALLY IMMEDIATE)');
+        $this->addSql('INSERT INTO notification (id, user_id, message, created_at) SELECT id, user_id, message, created_at FROM __temp__notification');
+        $this->addSql('DROP TABLE __temp__notification');
+        $this->addSql('CREATE INDEX IDX_BF5476CAA76ED395 ON notification (user_id)');
+    }
+}

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -17,8 +17,14 @@ class Notification
     #[ORM\Column(length: 255)]
     private string $message;
 
+    #[ORM\Column(length: 50)]
+    private string $level = 'info';
+
     #[ORM\Column(type: 'datetime_immutable')]
     private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $isRead = false;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'notifications')]
     #[ORM\JoinColumn(nullable: false)]
@@ -41,6 +47,18 @@ class Notification
         return $this;
     }
 
+    public function getLevel(): string
+    {
+        return $this->level;
+    }
+
+    public function setLevel(string $level): self
+    {
+        $this->level = $level;
+
+        return $this;
+    }
+
     public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
@@ -49,6 +67,18 @@ class Notification
     public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function isRead(): bool
+    {
+        return $this->isRead;
+    }
+
+    public function setIsRead(bool $isRead): self
+    {
+        $this->isRead = $isRead;
 
         return $this;
     }

--- a/tests/Entity/NotificationTest.php
+++ b/tests/Entity/NotificationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class NotificationTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $user = new User();
+        $notification = new Notification();
+        $notification->setMessage('Alert');
+        $notification->setLevel('warning');
+        $notification->setIsRead(true);
+        $date = new \DateTimeImmutable('2025-01-01');
+        $notification->setCreatedAt($date);
+        $notification->setUser($user);
+
+        $this->assertSame('Alert', $notification->getMessage());
+        $this->assertSame('warning', $notification->getLevel());
+        $this->assertTrue($notification->isRead());
+        $this->assertSame($date, $notification->getCreatedAt());
+        $this->assertSame($user, $notification->getUser());
+    }
+}

--- a/tests/Repository/NotificationRepositoryTest.php
+++ b/tests/Repository/NotificationRepositoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class NotificationRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        self::bootKernel();
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+        $this->entityManager = $entityManager;
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testPersistNotification(): void
+    {
+        $user = new User();
+        $user->setEmail('n@example.com');
+        $user->setPassword('x');
+        $this->entityManager->persist($user);
+
+        $notification = new Notification();
+        $notification->setUser($user);
+        $notification->setMessage('Budget exceeded');
+        $notification->setLevel('warning');
+        $notification->setCreatedAt(new \DateTimeImmutable());
+
+        $this->entityManager->persist($notification);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $repo = $this->entityManager->getRepository(Notification::class);
+        $found = $repo->findOneBy(['message' => 'Budget exceeded']);
+        $this->assertInstanceOf(Notification::class, $found);
+        $this->assertSame('warning', $found->getLevel());
+    }
+}


### PR DESCRIPTION
## Summary
- extend Notification entity with level and isRead fields
- document database changes
- add Notification usage guide
- create Doctrine migration for new columns
- test Notification entity and repository

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test` *(fails: jest not found)*
- `composer test`
- `composer phpstan`
- `vendor/bin/phpcs`
- `docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd92d729c832ca0cc1e93e89be126