### PR TITLE
Add budget checker service and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ npm run test
 See `docs/API_USAGE.md` for REST API usage.
 See `docs/JWT_KEYS.md` for generating JWT keys.
 See `docs/NOTIFICATIONS.md` for how notifications work.
+See `docs/BUDGET_CHECKER.md` for the budget checker endpoint.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,5 +16,7 @@ services:
     App\:
         resource: '../src/'
 
+    App\Service\BudgetCalculatorInterface: '@App\Service\BudgetCalculator'
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/docs/BUDGET_CHECKER.md
+++ b/docs/BUDGET_CHECKER.md
@@ -1,0 +1,25 @@
+# Budget Checker
+
+Use `/api/budget-check` to compare your spending with `BudgetLimit` settings. The endpoint returns totals for the month and creates notifications when limits are exceeded.
+
+## Request
+
+`GET /api/budget-check?month=YYYY-MM`
+
+- `month` is optional. Defaults to the current month.
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  http://localhost:8000/api/budget-check?month=2025-01
+```
+
+## Response
+
+```json
+{
+  "data": [
+    { "category": 1, "spent": 110, "limit": 100, "over": true },
+    { "category": 2, "spent": 150, "limit": 200, "over": false }
+  ]
+}
+```

--- a/src/Controller/BudgetCheckController.php
+++ b/src/Controller/BudgetCheckController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Service\BudgetCalculatorInterface;
+use App\Service\JsonApi;
+use DateTimeImmutable;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/budget-check')]
+final class BudgetCheckController extends AbstractController
+{
+    public function __construct(
+        private BudgetCalculatorInterface $calculator,
+        private JsonApi $jsonApi
+    ) {
+    }
+
+    #[Route('', methods: ['GET'])]
+    public function check(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $monthParam = (string) $request->query->get('month');
+        $month = $monthParam !== ''
+            ? new DateTimeImmutable($monthParam . '-01')
+            : new DateTimeImmutable('first day of this month');
+
+        $results = $this->calculator->checkMonthlyLimits($user, $month);
+
+        return new JsonResponse(['data' => $results]);
+    }
+}

--- a/src/Service/BudgetCalculator.php
+++ b/src/Service/BudgetCalculator.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\BudgetLimit;
+use App\Entity\Notification;
+use App\Entity\Transaction;
+use App\Entity\User;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class BudgetCalculator implements BudgetCalculatorInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    /**
+     * @return array<int, array{category: int, spent: int, limit: int, over: bool}>
+     */
+    public function checkMonthlyLimits(User $user, DateTimeImmutable $month): array
+    {
+        $start = $month->modify('first day of this month')->setTime(0, 0);
+        $end = $start->modify('last day of this month')->setTime(23, 59, 59);
+
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->select('IDENTITY(t.category) AS category', 'SUM(t.amount) AS spent')
+            ->from(Transaction::class, 't')
+            ->where('t.user = :user')
+            ->andWhere('t.date BETWEEN :start AND :end')
+            ->groupBy('category')
+            ->setParameters([
+                'user' => $user,
+                'start' => $start,
+                'end' => $end,
+            ]);
+
+        $spentData = [];
+        foreach ($qb->getQuery()->getArrayResult() as $row) {
+            $catId = (int) $row['category'];
+            $spentData[$catId] = (int) $row['spent'];
+        }
+
+        $results = [];
+        $limits = $this->entityManager->getRepository(BudgetLimit::class)
+            ->findBy(['user' => $user]);
+
+        foreach ($limits as $limit) {
+            $category = $limit->getCategory();
+            $catId = $category->getId();
+            if (!is_int($catId)) {
+                continue;
+            }
+            $spent = $spentData[$catId] ?? 0;
+            $over = $spent > $limit->getAmount();
+            $results[] = [
+                'category' => $catId,
+                'spent' => $spent,
+                'limit' => $limit->getAmount(),
+                'over' => $over,
+            ];
+
+            if ($over) {
+                $notification = new Notification();
+                $notification->setUser($user);
+                $notification->setMessage('Budget limit exceeded for ' . $category->getName());
+                $notification->setLevel('warning');
+                $notification->setIsRead(false);
+                $notification->setCreatedAt(new DateTimeImmutable());
+                $this->entityManager->persist($notification);
+            }
+        }
+
+        $this->entityManager->flush();
+
+        return $results;
+    }
+}

--- a/src/Service/BudgetCalculatorInterface.php
+++ b/src/Service/BudgetCalculatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\User;
+
+interface BudgetCalculatorInterface
+{
+    /**
+     * @return array<int, array{category: int, spent: int, limit: int, over: bool}>
+     */
+    public function checkMonthlyLimits(User $user, \DateTimeImmutable $month): array;
+}

--- a/tests/Controller/BudgetCheckControllerTest.php
+++ b/tests/Controller/BudgetCheckControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\BudgetLimit;
+use App\Entity\Category;
+use App\Entity\Transaction;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+class BudgetCheckControllerTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        self::bootKernel();
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        \assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testCheckEndpoint(): void
+    {
+        $user = new User();
+        $user->setEmail('t@example.com');
+        $user->setPassword('x');
+        $this->entityManager->persist($user);
+
+        $category = new Category();
+        $category->setName('Food');
+        $this->entityManager->persist($category);
+
+        $limit = new BudgetLimit();
+        $limit->setUser($user);
+        $limit->setCategory($category);
+        $limit->setAmount(100);
+        $this->entityManager->persist($limit);
+
+        $transaction = new Transaction();
+        $transaction->setUser($user);
+        $transaction->setCategory($category);
+        $transaction->setAmount(50);
+        $transaction->setDescription('meal');
+        $transaction->setDate(new \DateTimeImmutable('2025-01-05'));
+        $this->entityManager->persist($transaction);
+
+        $this->entityManager->flush();
+
+        /** @var HttpKernelBrowser $client */
+        $client = static::createClient();
+        $client->loginUser($user);
+        $client->request('GET', '/api/budget-check?month=2025-01');
+
+        $this->assertResponseIsSuccessful();
+        $data = json_decode($client->getResponse()->getContent(), true);
+        \assert(is_array($data));
+        $this->assertSame(1, count($data['data']));
+        $this->assertSame(50, $data['data'][0]['spent']);
+    }
+}

--- a/tests/Service/BudgetCalculatorTest.php
+++ b/tests/Service/BudgetCalculatorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\BudgetLimit;
+use App\Entity\Category;
+use App\Entity\Transaction;
+use App\Entity\User;
+use App\Service\BudgetCalculator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BudgetCalculatorTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        self::bootKernel();
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        \assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testCheckMonthlyLimitsCreatesNotification(): void
+    {
+        $user = new User();
+        $user->setEmail('a@example.com');
+        $user->setPassword('x');
+        $this->entityManager->persist($user);
+
+        $category = new Category();
+        $category->setName('Food');
+        $this->entityManager->persist($category);
+
+        $limit = new BudgetLimit();
+        $limit->setUser($user);
+        $limit->setCategory($category);
+        $limit->setAmount(100);
+        $this->entityManager->persist($limit);
+
+        $t1 = new Transaction();
+        $t1->setUser($user);
+        $t1->setCategory($category);
+        $t1->setAmount(70);
+        $t1->setDescription('A');
+        $t1->setDate(new \DateTimeImmutable('2025-01-05'));
+        $this->entityManager->persist($t1);
+
+        $t2 = new Transaction();
+        $t2->setUser($user);
+        $t2->setCategory($category);
+        $t2->setAmount(50);
+        $t2->setDescription('B');
+        $t2->setDate(new \DateTimeImmutable('2025-01-10'));
+        $this->entityManager->persist($t2);
+
+        $this->entityManager->flush();
+
+        $service = new BudgetCalculator($this->entityManager);
+        $result = $service->checkMonthlyLimits($user, new \DateTimeImmutable('2025-01-01'));
+
+        $this->assertTrue($result[0]['over']);
+        $notifications = $this->entityManager->getRepository(\App\Entity\Notification::class)->findAll();
+        $this->assertCount(1, $notifications);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `BudgetCalculator` service with `BudgetCalculatorInterface`
- expose new `/api/budget-check` endpoint
- document budget checker usage
- wire up the service via DI and update README
- cover service and endpoint with unit tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test` *(fails: jest not found)*
- `composer test` *(fails: phpunit not found)*
- `composer phpstan` *(fails: phpstan not found)*
- `composer phpcs` *(fails: phpcs not found)*
- `npm run build` *(fails: encore not found)*
- `docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c496ab470832c861263098db03327