### PR TITLE
Add REST and SSE notifications

### DIFF
--- a/assets/__tests__/request.test.js
+++ b/assets/__tests__/request.test.js
@@ -57,3 +57,10 @@ async function parseResponse(res) {
 }
 
 module.exports = { buildOptions, isValidJson, parseResponse };
+
+test('buildOptions sets auth header', () => {
+  const opts = buildOptions('POST', 't', '{}');
+  expect(opts.headers.Authorization).toBe('Bearer t');
+  expect(opts.headers['Content-Type']).toBe('application/json');
+  expect(opts.body).toBe('{}');
+});

--- a/config/routes/api/notification.yaml
+++ b/config/routes/api/notification.yaml
@@ -1,0 +1,4 @@
+api_notifications:
+    resource: '../../src/Controller/NotificationController.php'
+    type: attribute
+

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -19,3 +19,27 @@ curl -H "Authorization: Bearer <token>" http://localhost:8000/api/notifications
 
 Notifications are generated nightly by the `app:generate-notifications` command.
 Run it manually with `php bin/console app:generate-notifications`.
+
+## API
+
+### List unread notifications
+
+`GET /api/notifications?page=1&limit=10`
+
+Returns unread items by default. Pass `isRead=true` to view archived ones.
+
+### Mark as read
+
+`PATCH /api/notifications/{id}/read`
+
+### Mark all as read
+
+`PATCH /api/notifications/read-all`
+
+### Live updates
+
+`GET /api/notifications/stream`
+
+Streams unread notifications as Server-Sent Events.
+
+

--- a/src/Controller/NotificationController.php
+++ b/src/Controller/NotificationController.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use App\Service\JsonApi;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/notifications')]
+class NotificationController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private JsonApi $jsonApi
+    ) {
+    }
+
+    #[Route('', methods: ['GET'])]
+    public function list(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $page = max(1, (int) $request->query->get('page', '1'));
+        $limit = max(1, (int) $request->query->get('limit', '10'));
+        $isRead = $request->query->get('isRead', 'false') === 'true';
+
+        $qb = $this->entityManager->getRepository(Notification::class)
+            ->createQueryBuilder('n')
+            ->where('n.user = :user')
+            ->andWhere('n.isRead = :isRead')
+            ->setParameter('user', $user)
+            ->setParameter('isRead', $isRead)
+            ->orderBy('n.createdAt', 'DESC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit);
+
+        /** @var array<int, Notification> $notifications */
+        $notifications = $qb->getQuery()->getResult();
+
+        $items = [];
+        foreach ($notifications as $notification) {
+            if (!$notification instanceof Notification) {
+                continue;
+            }
+            $items[] = [
+                'type' => 'notification',
+                'id' => (string) $notification->getId(),
+                'attributes' => [
+                    'message' => $notification->getMessage(),
+                    'level' => $notification->getLevel(),
+                    'createdAt' => $notification->getCreatedAt()->format(DATE_ATOM),
+                    'isRead' => $notification->isRead(),
+                ],
+            ];
+        }
+
+        return new JsonResponse($this->jsonApi->collection($items));
+    }
+
+    #[Route('/{id}/read', methods: ['PATCH'])]
+    public function markRead(Notification $notification): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($notification->getUser()->getId() !== $user->getId()) {
+            return new JsonResponse(['errors' => [['detail' => 'Not found']]], 404);
+        }
+
+        $notification->setIsRead(true);
+        $this->entityManager->flush();
+
+        $id = $notification->getId();
+        \assert(is_int($id));
+
+        return new JsonResponse(
+            $this->jsonApi->item('notification', $id, [
+                'message' => $notification->getMessage(),
+                'level' => $notification->getLevel(),
+                'createdAt' => $notification->getCreatedAt()->format(DATE_ATOM),
+                'isRead' => $notification->isRead(),
+            ])
+        );
+    }
+
+    #[Route('/read-all', methods: ['PATCH'])]
+    public function markAllRead(): JsonResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $this->entityManager->createQuery(
+            'UPDATE App\\Entity\\Notification n SET n.isRead = true WHERE n.user = :user AND n.isRead = false'
+        )->setParameter('user', $user)->execute();
+
+        return new JsonResponse(null, 204);
+    }
+
+    #[Route('/stream', methods: ['GET'])]
+    public function streamEvents(): StreamedResponse
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $notifications = $this->entityManager->getRepository(Notification::class)
+            ->findBy(['user' => $user, 'isRead' => false], ['id' => 'ASC']);
+
+        $response = new StreamedResponse(function () use ($notifications): void {
+            foreach ($notifications as $notification) {
+                if (!$notification instanceof Notification) {
+                    continue;
+                }
+                $id = $notification->getId();
+                \assert(is_int($id));
+                $data = json_encode([
+                    'message' => $notification->getMessage(),
+                    'level' => $notification->getLevel(),
+                    'createdAt' => $notification->getCreatedAt()->format(DATE_ATOM),
+                    'isRead' => $notification->isRead(),
+                ]);
+                echo "id: {$id}\n";
+                echo "data: {$data}\n\n";
+                ob_flush();
+                flush();
+            }
+        });
+        $response->headers->set('Content-Type', 'text/event-stream');
+        $response->headers->set('Cache-Control', 'no-cache');
+
+        return $response;
+    }
+}

--- a/tests/Controller/NotificationControllerTest.php
+++ b/tests/Controller/NotificationControllerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\Notification;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class NotificationControllerTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        self::bootKernel();
+        $container = static::getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        \assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    /**
+     * @return array{0: User, 1: Notification, 2: Notification, 3: Notification}
+     */
+    private function createUserWithNotifications(): array
+    {
+        $user = new User();
+        $user->setEmail('n@example.com');
+        $user->setPassword('x');
+        $this->entityManager->persist($user);
+
+        $n1 = new Notification();
+        $n1->setUser($user);
+        $n1->setMessage('A');
+        $n1->setLevel('info');
+        $n1->setCreatedAt(new \DateTimeImmutable());
+        $this->entityManager->persist($n1);
+
+        $n2 = new Notification();
+        $n2->setUser($user);
+        $n2->setMessage('B');
+        $n2->setLevel('info');
+        $n2->setCreatedAt(new \DateTimeImmutable());
+        $n2->setIsRead(true);
+        $this->entityManager->persist($n2);
+
+        $n3 = new Notification();
+        $n3->setUser($user);
+        $n3->setMessage('C');
+        $n3->setLevel('warning');
+        $n3->setCreatedAt(new \DateTimeImmutable());
+        $this->entityManager->persist($n3);
+
+        $this->entityManager->flush();
+
+        return [$user, $n1, $n2, $n3];
+    }
+
+    public function testList(): void
+    {
+        [$user] = $this->createUserWithNotifications();
+
+        /** @var KernelBrowser $client */
+        $client = static::createClient();
+        $client->loginUser($user);
+        /* @phpstan-ignore-next-line */
+        $client->request('GET', '/api/notifications');
+
+        $this->assertResponseIsSuccessful();
+        /* @phpstan-ignore-next-line */
+        $data = json_decode($client->getResponse()->getContent(), true);
+        \assert(is_array($data));
+        $this->assertCount(2, $data['data']);
+    }
+
+    public function testMarkRead(): void
+    {
+        [$user, $n1] = $this->createUserWithNotifications();
+
+        /** @var KernelBrowser $client */
+        $client = static::createClient();
+        $client->loginUser($user);
+        $id = $n1->getId();
+        \assert(is_int($id));
+        /* @phpstan-ignore-next-line */
+        $client->request('PATCH', '/api/notifications/' . $id . '/read');
+
+        $this->assertResponseIsSuccessful();
+        $this->entityManager->clear();
+        $updated = $this->entityManager->find(Notification::class, $id);
+        \assert($updated instanceof Notification);
+        $this->assertTrue($updated->isRead());
+    }
+
+    public function testMarkAllRead(): void
+    {
+        [$user] = $this->createUserWithNotifications();
+
+        /** @var KernelBrowser $client */
+        $client = static::createClient();
+        $client->loginUser($user);
+        /* @phpstan-ignore-next-line */
+        $client->request('PATCH', '/api/notifications/read-all');
+        $this->assertResponseStatusCodeSame(204);
+
+        $unread = $this->entityManager->getRepository(Notification::class)
+            ->findBy(['user' => $user, 'isRead' => false]);
+        $this->assertCount(0, $unread);
+    }
+
+    public function testStream(): void
+    {
+        [$user] = $this->createUserWithNotifications();
+
+        /** @var KernelBrowser $client */
+        $client = static::createClient();
+        $client->loginUser($user);
+        /* @phpstan-ignore-next-line */
+        $client->request('GET', '/api/notifications/stream');
+        $this->assertResponseIsSuccessful();
+        /* @phpstan-ignore-next-line */
+        $this->assertSame('text/event-stream', $client->getResponse()->headers->get('Content-Type'));
+        /* @phpstan-ignore-next-line */
+        $this->assertStringContainsString('data:', $client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- implement NotificationController with list, read, read-all, and SSE actions
- route controller via new config
- document notification API usage
- test NotificationController and fix JS tests

## Testing
- `composer phpstan`
- `composer phpcs`
- `composer test`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684decb323dc832c8eb2299af1c3757d