### PR TITLE
Remove Qodana command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Run the following commands inside the container to execute the test suite and qu
 docker compose run --rm app composer test
 docker compose run --rm app composer phpstan
 docker compose run --rm app composer phpcs
-docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0
 npm run lint
 npm run test
 ```

--- a/codex.custom.yml
+++ b/codex.custom.yml
@@ -7,4 +7,3 @@ rules:
       - run: composer test
       - run: composer phpstan
       - run: composer phpcs
-      - run: docker run --rm -v $(pwd):/data/project jetbrains/qodana-php --fail-threshold 0


### PR DESCRIPTION
## Summary
- drop Qodana step from Codex workflow
- update README quality instructions

## Testing
- `npm run lint`
- `npm run test`
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e9f7c4230832c8d9b84f1a2004250