### PR TITLE
Add notification dropdown UI

### DIFF
--- a/assets/__tests__/stores/notifications.test.js
+++ b/assets/__tests__/stores/notifications.test.js
@@ -27,3 +27,19 @@ test('fetchList updates items', async () => {
   expect(store.items).toHaveLength(1);
 });
 
+test('connectStream falls back to polling', () => {
+  const auth = useAuthStore();
+  auth.token = 't';
+  const store = useNotificationStore();
+  jest.useFakeTimers();
+  const spySet = jest.spyOn(global, 'setInterval');
+  global.EventSource = undefined;
+  store.connectStream();
+  expect(spySet).toHaveBeenCalled();
+  jest.advanceTimersByTime(30000);
+  expect(spySet).toHaveBeenCalled();
+  store.disconnect();
+  spySet.mockRestore();
+  jest.useRealTimers();
+});
+

--- a/assets/vue/App.vue
+++ b/assets/vue/App.vue
@@ -1,13 +1,14 @@
 <template>
   <div>
+    <header class="header">
+      <NotificationBell />
+    </header>
     <h1>Hello Vue!</h1>
     <p><a href="/docs">View Documentation</a></p>
   </div>
 </template>
 
-<script>
-export default {
-  name: 'App'
-}
+<script setup>
+import NotificationBell from './components/NotificationBell.vue';
 </script>
 

--- a/assets/vue/components/NotificationBell.vue
+++ b/assets/vue/components/NotificationBell.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="notification-bell" @click="toggle">
+    <span class="icon">🔔</span>
+    <span v-if="unread > 0" class="badge">{{ unread }}</span>
+    <NotificationDropdown
+      v-if="open"
+      :notifications="items"
+      @mark-all-read="handleMarkAll"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue';
+import NotificationDropdown from './NotificationDropdown.vue';
+import { useNotificationStore } from '../../stores/notifications';
+
+const store = useNotificationStore();
+const { items, unread, fetchList, markAllRead, connectStream, disconnect } = store;
+
+const open = ref(false);
+
+function toggle() {
+  open.value = !open.value;
+}
+
+function handleMarkAll() {
+  markAllRead();
+}
+
+onMounted(() => {
+  connectStream();
+  fetchList();
+});
+
+onUnmounted(() => {
+  disconnect();
+});
+</script>
+
+<style scoped>
+.notification-bell {
+  position: relative;
+  cursor: pointer;
+  display: inline-block;
+}
+.icon {
+  font-size: 1.5rem;
+}
+.badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: red;
+  color: #fff;
+  border-radius: 50%;
+  padding: 0 4px;
+  font-size: 0.75rem;
+}
+</style>

--- a/assets/vue/components/NotificationDropdown.vue
+++ b/assets/vue/components/NotificationDropdown.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="dropdown">
+    <ul class="list">
+      <li
+        v-for="n in notifications"
+        :key="n.id"
+        :class="n.level"
+        class="item"
+      >
+        <span class="msg">{{ n.message }}</span>
+        <small class="time">{{ formatDate(n.createdAt) }}</small>
+      </li>
+    </ul>
+    <button
+      v-if="unread > 0"
+      type="button"
+      @click="markAllRead"
+      class="mark-all"
+    >Mark all read</button>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  notifications: {
+    type: Array,
+    default: () => [],
+  },
+});
+const emit = defineEmits(['mark-all-read']);
+
+function markAllRead() {
+  emit('mark-all-read');
+}
+
+function formatDate(d) {
+  return new Date(d).toLocaleString();
+}
+
+const unread = computed(() => props.notifications.filter(n => !n.isRead).length);
+</script>
+
+<style scoped>
+.dropdown {
+  position: absolute;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  min-width: 200px;
+}
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.item {
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 0;
+}
+.msg {
+  margin-right: 0.5rem;
+}
+.mark-all {
+  margin-top: 0.5rem;
+}
+</style>

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -42,4 +42,12 @@ Returns unread items by default. Pass `isRead=true` to view archived ones.
 
 Streams unread notifications as Server-Sent Events.
 
+## Notification Center UI
+
+After logging in, a bell icon appears in the top-right corner of the app. It
+shows the number of unread notifications. Click the bell to open a dropdown
+listing recent alerts and a **Mark all read** button. The store connects to the
+`/api/notifications/stream` endpoint when possible and falls back to polling the
+list every 30 seconds when SSE is unavailable.
+
 


### PR DESCRIPTION
## Summary
- create NotificationBell and NotificationDropdown components
- stream notifications with SSE and poll fallback
- expose the bell in App.vue
- update notifications store
- document the Notification Center UI
- test SSE fallback logic for notifications store

## Testing
- `npm run lint`
- `npm run test`
- `composer test`
- `composer phpstan`
- `composer phpcs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ea4d6a0c4832cb71164aab9c2dc91