### PR TITLE
Add validation layer

### DIFF
--- a/assets/__tests__/validation/transactionSchema.test.js
+++ b/assets/__tests__/validation/transactionSchema.test.js
@@ -1,0 +1,20 @@
+const { transactionSchema } = require('../../js/validation/transactionSchema');
+
+test('valid transaction passes', async () => {
+  const data = {
+    amount: 5,
+    description: 'foo',
+    date: '2000-01-01',
+    category: 1,
+  };
+  await expect(transactionSchema.isValid(data)).resolves.toBe(true);
+});
+
+test('future date fails', async () => {
+  const data = {
+    amount: 5,
+    description: 'foo',
+    date: '2999-01-01',
+  };
+  await expect(transactionSchema.isValid(data)).resolves.toBe(false);
+});

--- a/assets/js/validation/budgetLimitSchema.js
+++ b/assets/js/validation/budgetLimitSchema.js
@@ -1,0 +1,8 @@
+const yup = require('yup');
+
+const budgetLimitSchema = yup.object({
+  amount: yup.number().required().positive(),
+  category: yup.number().required().positive(),
+});
+
+module.exports = { budgetLimitSchema };

--- a/assets/js/validation/savingsGoalSchema.js
+++ b/assets/js/validation/savingsGoalSchema.js
@@ -1,0 +1,8 @@
+const yup = require('yup');
+
+const savingsGoalSchema = yup.object({
+  targetAmount: yup.number().required().positive(),
+  currentAmount: yup.number().required().min(0),
+});
+
+module.exports = { savingsGoalSchema };

--- a/assets/js/validation/transactionSchema.js
+++ b/assets/js/validation/transactionSchema.js
@@ -1,0 +1,10 @@
+const yup = require('yup');
+
+const transactionSchema = yup.object({
+  amount: yup.number().required().positive(),
+  description: yup.string().required(),
+  date: yup.date().max(new Date(), 'Date cannot be in the future').required(),
+  category: yup.number().nullable(),
+});
+
+module.exports = { transactionSchema };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
             "dependencies": {
                 "chart.js": "^4.4.1",
                 "pinia": "^3.0.3",
-                "vue-chartjs": "^5.3.2"
+                "vee-validate": "^4.11.5",
+                "vue-chartjs": "^5.3.2",
+                "yup": "^1.3.2"
             },
             "devDependencies": {
                 "@babel/core": "^7.17.0",
@@ -9539,6 +9541,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/property-expr": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+            "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+            "license": "MIT"
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10439,6 +10447,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tiny-case": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+            "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+            "license": "MIT"
+        },
         "node_modules/tmp": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -10468,6 +10482,12 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/toposort": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+            "license": "MIT"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -10624,6 +10644,31 @@
             },
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/vee-validate": {
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.1.tgz",
+            "integrity": "sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-api": "^7.5.2",
+                "type-fest": "^4.8.3"
+            },
+            "peerDependencies": {
+                "vue": "^3.4.26"
+            }
+        },
+        "node_modules/vee-validate/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/vue": {
@@ -11144,6 +11189,30 @@
             "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yup": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+            "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+            "license": "MIT",
+            "dependencies": {
+                "property-expr": "^2.0.5",
+                "tiny-case": "^1.0.3",
+                "toposort": "^2.0.2",
+                "type-fest": "^2.19.0"
+            }
+        },
+        "node_modules/yup/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=12.20"
             },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "dependencies": {
         "pinia": "^3.0.3",
         "chart.js": "^4.4.1",
-        "vue-chartjs": "^5.3.2"
+        "vue-chartjs": "^5.3.2",
+        "vee-validate": "^4.11.5",
+        "yup": "^1.3.2"
     }
 }

--- a/src/Dto/BudgetLimitData.php
+++ b/src/Dto/BudgetLimitData.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class BudgetLimitData
+{
+    #[Assert\GreaterThan(0)]
+    public int $amount;
+
+    #[Assert\Positive]
+    public int $category;
+
+    public function __construct(int $amount = 0, int $category = 0)
+    {
+        $this->amount = $amount;
+        $this->category = $category;
+    }
+}

--- a/src/Dto/SavingsGoalData.php
+++ b/src/Dto/SavingsGoalData.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class SavingsGoalData
+{
+    #[Assert\GreaterThan(0)]
+    public int $targetAmount;
+
+    #[Assert\GreaterThanOrEqual(0)]
+    public int $currentAmount;
+
+    public function __construct(int $targetAmount = 0, int $currentAmount = 0)
+    {
+        $this->targetAmount = $targetAmount;
+        $this->currentAmount = $currentAmount;
+    }
+}

--- a/src/Dto/TransactionData.php
+++ b/src/Dto/TransactionData.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Validator\Constraints\NoFutureDate;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class TransactionData
+{
+    #[Assert\GreaterThan(0)]
+    public int $amount;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public string $description;
+
+    #[Assert\NotNull]
+    #[NoFutureDate]
+    public \DateTimeImmutable $date;
+
+    #[Assert\Positive]
+    public ?int $category;
+
+    public function __construct(
+        int $amount = 0,
+        string $description = '',
+        ?\DateTimeImmutable $date = null,
+        ?int $category = null
+    ) {
+        $this->amount = $amount;
+        $this->description = $description;
+        $this->date = $date ?? new \DateTimeImmutable();
+        $this->category = $category;
+    }
+}

--- a/src/Validator/Constraints/NoFutureDate.php
+++ b/src/Validator/Constraints/NoFutureDate.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+class NoFutureDate extends Constraint
+{
+    public string $message = 'Date cannot be in the future.';
+
+    public function validatedBy(): string
+    {
+        return static::class . 'Validator';
+    }
+}

--- a/src/Validator/Constraints/NoFutureDateValidator.php
+++ b/src/Validator/Constraints/NoFutureDateValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class NoFutureDateValidator extends ConstraintValidator
+{
+    /**
+     * @param \DateTimeInterface|null $value
+     * @param NoFutureDate $constraint
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$value instanceof \DateTimeInterface) {
+            return;
+        }
+
+        $now = new \DateTimeImmutable();
+        if ($value > $now) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}

--- a/tests/Controller/TransactionControllerTest.php
+++ b/tests/Controller/TransactionControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Entity\Category;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TransactionControllerTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private KernelBrowser $client;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        if (!extension_loaded('pdo_sqlite')) {
+            self::markTestSkipped('pdo_sqlite missing');
+        }
+        $this->client = static::createClient();
+        $container = $this->client->getContainer();
+        $em = $container->get(EntityManagerInterface::class);
+        \assert($em instanceof EntityManagerInterface);
+        $this->entityManager = $em;
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testCreateInvalidData(): void
+    {
+        $user = new User();
+        $user->setEmail('t@example.com');
+        $user->setPassword('x');
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'POST',
+            '/api/transactions',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['amount' => 0, 'description' => 'bad', 'date' => '2999-01-01']) ?: ''
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testCreateValidData(): void
+    {
+        $user = new User();
+        $user->setEmail('t@example.com');
+        $user->setPassword('x');
+        $this->entityManager->persist($user);
+
+        $category = new Category();
+        $category->setName('Food');
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+
+        $this->client->loginUser($user);
+        $this->client->request(
+            'POST',
+            '/api/transactions',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'amount' => 5,
+                'description' => 'ok',
+                'date' => '2000-01-01',
+                'category' => $category->getId(),
+            ]) ?: ''
+        );
+
+        $this->assertResponseStatusCodeSame(201);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `NoFutureDate` constraint and validator
- validate request payloads with new DTOs for transactions, budget limits and savings goals
- add transaction validator test and update controllers
- provide vee-validate schemas for front-end forms
- cover validation logic in unit tests

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`
- `composer test`
- `php -d memory_limit=512M vendor/bin/phpstan analyse`
- `composer phpcs`

------
https://chatgpt.com/codex/tasks/task_e_687b81d14cd8832cb21abadf95bcb8ca