### PR TITLE
Add production compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@
 FROM node:18 AS frontend
 
 WORKDIR /app
+ENV NODE_ENV=production
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --omit=dev && npm cache clean --force
 
 COPY assets ./assets
 COPY webpack.config.js ./

--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ See `docs/API_USAGE.md` for REST API usage.
 See `docs/JWT_KEYS.md` for generating JWT keys.
 See `docs/NOTIFICATIONS.md` for how notifications work.
 See `docs/BUDGET_CHECKER.md` for the budget checker endpoint.
+See `docs/PRODUCTION.md` for deploying with Docker Compose.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,33 @@
+services:
+  app:
+    build:
+      context: .
+    environment:
+      APP_ENV: prod
+    volumes:
+      - sqlite-data:/var/www/html/var
+    expose:
+      - "9000"
+
+  cron:
+    build:
+      context: .
+    command: >-
+      sh -c "echo '0 0 * * * php /var/www/html/bin/console app:generate-notifications >> /proc/1/fd/1 2>&1' > /etc/crontabs/app && crond -f -L /proc/1/fd/1"
+    volumes:
+      - sqlite-data:/var/www/html/var
+    depends_on:
+      - app
+
+  web:
+    image: nginx:1.25-alpine
+    volumes:
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./public:/var/www/html/public:ro
+    ports:
+      - "8000:80"
+    depends_on:
+      - app
+
+volumes:
+  sqlite-data:

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,13 @@
+# Production Setup
+
+Use `docker-compose.prod.yml` to build and run Budgertia in production.
+It mounts the SQLite database to the `sqlite-data` volume and runs a cron
+container that triggers `app:generate-notifications` nightly.
+
+## Build and Start
+
+```bash
+docker compose -f docker-compose.prod.yml up --build -d
+```
+
+The web server listens on port `8000`.

--- a/tests/Infrastructure/ProdComposeTest.php
+++ b/tests/Infrastructure/ProdComposeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Infrastructure;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class ProdComposeTest extends TestCase
+{
+    public function testCronServiceExists(): void
+    {
+        /** @var array<string, mixed> $data */
+        $data = Yaml::parseFile(__DIR__ . '/../../docker-compose.prod.yml');
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('services', $data);
+        $services = $data['services'];
+        $this->assertIsArray($services);
+        $this->assertArrayHasKey('cron', $services);
+        $this->assertArrayHasKey('volumes', $data);
+        $volumes = $data['volumes'];
+        $this->assertIsArray($volumes);
+        $this->assertArrayHasKey('sqlite-data', $volumes);
+    }
+}


### PR DESCRIPTION
## Summary
- add docker-compose.prod.yml for production
- make Node build smaller via `npm ci --omit=dev`
- document production stack
- mention prod docs in README
- test prod compose config

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`
- `composer test`
- `php -d memory_limit=512M vendor/bin/phpstan analyse`
- `composer phpcs`


------
https://chatgpt.com/codex/tasks/task_e_687bbeca9868832c806a0d1fc1c6af0e